### PR TITLE
Use libudev for device identification, print meta and identify always.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ rng: common.o utils.o rng.c
 	$(CC) $(CFLAGS) rng.c common.o utils.o -o rng
 
 discovery: common.o utils.o discovery.c
-	$(CC) $(CFLAGS) discovery.c common.o utils.o -o discovery
+	$(CC) $(CFLAGS) discovery.c common.o utils.o -o discovery -ludev
 
 control: common.o utils.o control.c
 	$(CC) $(CFLAGS) control.c common.o utils.o -o control

--- a/common.c
+++ b/common.c
@@ -1054,10 +1054,18 @@ int disk_device_open(struct disk_device *dev, const char *file, bool use_scsi_se
         return 1;
     }
 
+    if (dev->name)
+        free(dev->name);
+    if (!strncmp(file, "/dev/", 5))
+        dev->name = strdup(&file[5]);
+    else
+        dev->name = strdup(file);
+
     return 0;
 }
 
 void disk_device_close(struct disk_device *dev)
 {
     close(dev->fd);
+    free(dev->name);
 }

--- a/common.h
+++ b/common.h
@@ -400,6 +400,7 @@ struct disk_device {
         SCSI,
     } type;
 
+    char *name;
     uint16_t base_com_id;
     uint32_t host_session_id;
     uint32_t sp_session_id;

--- a/discovery.c
+++ b/discovery.c
@@ -233,7 +233,7 @@ static void print_level_0_discovery(struct disk_device *dev)
         size_t body_len = header->length + 4;
 
         print_comma_start(&first);
-        printf("  \"0x%x\": { \"data\": 0x", header->feature_code);
+        printf("  \"0x%x\": { \"data\": \"0x", header->feature_code);
         for (size_t j = 0; j < body_len; ++j) {
             printf("%02x", ((unsigned char *)header)[j]);
         }
@@ -474,6 +474,7 @@ static int print_udev_identify(const char *name)
     if (print_property(dev, "ID_VENDOR_ENC", "Vendor"))
         print_property(dev, "ID_VENDOR", "Vendor");
     print_property(dev, "ID_SERIAL", "Serial number long");
+    printf("  \"Source\": \"udev\"\n");
 
     udev_device_unref(dev);
     udev_unref(udev);
@@ -885,7 +886,7 @@ static int print_discovery(struct disk_device *dev, int selection)
             unsigned char random[128] = { 0 };
 
             if ((err = get_random(dev, random, sizeof(random)))) {
-                printf("  \"error\": \"%s\"", error_to_string(err));
+                printf("  \"error: %s\"", error_to_string(err));
                 break;
             }
             printf("%s  [\n", i == 0 ? "" : ",\n");

--- a/discovery.c
+++ b/discovery.c
@@ -443,7 +443,7 @@ static int print_property(struct udev_device *dev, const char *prop, const char 
     if (!p)
         return 1;
 
-    if (!strcmp(prop, "ID_MODEL_ENC"))
+    if (!strcmp(prop, "ID_MODEL_ENC") || !strcmp(prop, "ID_VENDOR_ENC"))
         unhexmangle_string(p);
     normalize_whitespace(p);
     printf("  \"%s\": \"%s\",\n", desc, p);
@@ -471,6 +471,9 @@ static int print_udev_identify(const char *name)
     print_property(dev, "ID_REVISION", "Firmware version");
     if (print_property(dev, "ID_MODEL_ENC", "Model number"))
         print_property(dev, "ID_MODEL", "Model number");
+    if (print_property(dev, "ID_VENDOR_ENC", "Vendor"))
+        print_property(dev, "ID_VENDOR", "Vendor");
+    print_property(dev, "ID_SERIAL", "Serial number long");
 
     udev_device_unref(dev);
     udev_unref(udev);


### PR DESCRIPTION
Use libudev for device identification, print meta and identify always.
    
Identify command sometimes fails (through USB adapter), it is safer to get id information through udev.
    
Also print identify and metadata information always in JSON.
