### PR TITLE
Improve rng utility.

### DIFF
--- a/rng.c
+++ b/rng.c
@@ -3,6 +3,48 @@
 #include "common.h"
 #include "utils.h"
 
+#include <errno.h>
+
+enum arg_keys
+{
+    ARG_KEY_DEVICE_FILE = 'd',
+    ARG_KEY_REQ_BYTES = 'b',
+    ARG_KEY_REQ_REPEATS = 'r',
+    ARG_KEY_OUTPUT_FILE = 'o',
+    ARG_KEY_LOG_LEVEL = 'l',
+    ARG_KEY_USE_SCSI = 's',
+    ARG_KEY_HEX_OUTPUT = 'x',
+};
+
+static struct argp_option options[] = {
+    { "device", ARG_KEY_DEVICE_FILE, "device", 0, "Disk device", 0 },
+    { "bytes", ARG_KEY_REQ_BYTES, "number of bytes", 0, "Number of random bytes within a sequence", 0 },
+    { "repeats", ARG_KEY_REQ_REPEATS, "number of repeats", 0, "Number of random byte sequences to acquire", 0 },
+    { "output", ARG_KEY_OUTPUT_FILE, "file", 0, "Output file", 0 },
+    { "log-level", ARG_KEY_LOG_LEVEL, "level", 0, "Log level", 0 },
+    { "scsi", ARG_KEY_USE_SCSI, 0, 0, "Use SCSI", 0 },
+    { "hex", ARG_KEY_HEX_OUTPUT, 0, 0, "Output random bytes in hexadecimal", 0 },
+    { 0 }
+};
+
+struct arguments
+{
+    char *dev_file;
+    char *out_file_name;
+    size_t req_bytes;
+    size_t req_repeats;
+    bool use_scsi_sec;
+    bool hex_output;
+} args = {
+    .dev_file = NULL,
+    .out_file_name = NULL,
+    .req_bytes = 32,
+    .req_repeats = 1,
+    .use_scsi_sec = false,
+    .hex_output = false,
+};
+
+// TODO update or replace with arpg_usage function
 static void print_usage(char *prog_name)
 {
     fprintf(stderr,
@@ -14,76 +56,116 @@ static void print_usage(char *prog_name)
     exit(1);
 }
 
+// TODO indicate cause of error
+static error_t parse_num(char *num_str, size_t *num_out)
+{
+    char *end;
+    long tmp;
+    errno = 0;
+
+    tmp = strtol(num_str, &end, 10);
+
+    if (errno != 0 || num_str == end || *end != '\0' || tmp <= 0) {
+        return 1;
+    }
+
+    *num_out = tmp;
+    return 0;
+}
+
+static error_t parse_opt(int key, char *arg, struct argp_state *state)
+{
+    struct arguments *args = state->input;
+
+    switch (key) {
+    case ARG_KEY_DEVICE_FILE:
+        args->dev_file = arg;
+        break;
+    case ARG_KEY_REQ_BYTES:
+        if (parse_num(arg, &args->req_bytes)) {
+            return 1;
+        }
+        break;
+    case ARG_KEY_REQ_REPEATS:
+        if (parse_num(arg, &args->req_repeats)) {
+            return 1;
+        }
+        break;
+    case ARG_KEY_OUTPUT_FILE:
+        args->out_file_name = arg;
+        break;
+    case ARG_KEY_LOG_LEVEL:
+        size_t tmp;
+        if (parse_num(arg, &tmp) || tmp < ERROR || tmp > EVERYTHING) {
+            return 1;
+        }
+        current_log_level = tmp;
+        break;
+    case ARG_KEY_USE_SCSI:
+        args->use_scsi_sec = true;
+    case ARG_KEY_HEX_OUTPUT:
+        args->hex_output = true;
+    default:
+        return ARGP_ERR_UNKNOWN;
+    }
+
+    return 0;
+}
+
+static struct argp argp = { options, parse_opt, 0, 0 };
+
 int main(int argc, char **argv)
 {
     int err = 0;
-    const char *dev_file = NULL;
-    int req_repeats = 1;
-    int req_bytes = 32;
-    bool use_scsi_sec = false;
     unsigned char *buffer = NULL;
 
-    if (argc > 2 && !strcmp(argv[argc - 1], "--scsi")) {
-        use_scsi_sec = true;
-        argc--;
+    if (argp_parse(&argp, argc, argv, 0, 0, &args) || args.dev_file == NULL) {
+        print_usage("rng");
+        err = 1;
+        goto exit;
     }
 
-    switch (argc) {
-    case 5:
-        current_log_level = atoi(argv[4]);
-        if (current_log_level < ERROR || current_log_level > EVERYTHING) {
-            print_usage(argv[0]);
-        }
-        // fallthrough
-    case 4:
-        req_repeats = atoi(argv[3]);
-        if (req_repeats <= 0) {
-            print_usage(argv[0]);
-        }
-        // fallthrough
-    case 3:
-        req_bytes = atoi(argv[2]);
-        if (req_bytes <= 0) {
-            print_usage(argv[0]);
-        }
-        // fallthrough
-    case 2:
-        if (argv[1][0] == '-') {
-            print_usage(argv[0]);
-        }
-        dev_file = argv[1];
-        break;
-    default:
-        print_usage(argv[0]);
-    }
-
-    if (!(buffer = malloc(req_bytes))) {
-            LOG(ERROR, "Out of memory.\n");
-            return 1;
+    if (!(buffer = malloc(args.req_bytes))) {
+        LOG(ERROR, "Out of memory.\n");
+        err = 1;
+        goto exit;
     }
 
     struct disk_device dev = { 0 };
-    if ((err = disk_device_open(&dev, dev_file, use_scsi_sec))) {
-        return err;
+    if ((err = disk_device_open(&dev, args.dev_file, args.use_scsi_sec))) {
+        LOG(ERROR, "Failed to open device file.\n");
+        err = 1;
+        goto buffer_cleanup;
     }
 
-    for (int req_i = 0; req_i < req_repeats; ++req_i) {
+    FILE *out = stdout;
+    if (args.out_file_name != NULL && (out = fopen(args.out_file_name, "a")) == NULL) {
+        LOG(ERROR, "Failed to open output file.\n");
+        err = 1;
+        goto disk_cleanup;
+    }
 
-        memset(buffer, 0, req_bytes);
+    for (int req_i = 0; req_i < args.req_repeats; ++req_i) {
+        memset(buffer, 0, args.req_bytes);
 
-        if ((err = get_random(&dev, buffer, req_bytes))) {
+        if ((err = get_random(&dev, buffer, args.req_bytes))) {
             LOG(ERROR, "Failed to get random data.\n");
             break;
         }
 
-        for (int byte_i = 0; byte_i < req_bytes; ++byte_i) {
-            printf("%02x", buffer[byte_i]);
-        };
-        printf("\n");
+        // TODO allow hexadecimal output
+        if (fwrite(buffer, sizeof(char), args.req_bytes, out) != args.req_bytes) {
+            LOG(ERROR, "Failed to write random data.\n");
+            err = 1;
+            break;
+        }
     }
 
+    fclose(out);
+disk_cleanup:
     disk_device_close(&dev);
+buffer_cleanup:
     free(buffer);
-
+exit:
     return err;
 }

--- a/rng.c
+++ b/rng.c
@@ -110,8 +110,11 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
         break;
     case ARG_KEY_USE_SCSI:
         args->use_scsi_sec = true;
+	break;
     case ARG_KEY_HEX_OUTPUT:
-        args->hex_output = true;
+        // args->hex_output = true;
+	fprintf(stderr, "Option -%c not implemented.\n", ARG_KEY_HEX_OUTPUT);
+	print_usage("rng");
     default:
         return ARGP_ERR_UNKNOWN;
     }

--- a/rng.c
+++ b/rng.c
@@ -161,8 +161,8 @@ int main(int argc, char **argv)
 
             if ((err = get_random(&dev, buffer, current_req_bytes))) {
                 LOG(ERROR, "Failed to get random data.\n");
-                err = 1;
-                break;
+                sleep(5);
+                continue;
             }
 
             // TODO allow hexadecimal output

--- a/rng.c
+++ b/rng.c
@@ -170,7 +170,9 @@ int main(int argc, char **argv)
 
         // TODO allow hexadecimal output
         // TODO decide on using fopen or open solely
-        if (fwrite(buffer, sizeof(char), current_req_bytes, out) != current_req_bytes) {
+        size_t written = fwrite(buffer, sizeof(char), current_req_bytes, out);
+        fflush(out);
+        if (written != current_req_bytes) {
             LOG(ERROR, "Failed to write random data.\n");
             err = 1;
             break;

--- a/rng.c
+++ b/rng.c
@@ -5,13 +5,11 @@
 
 #include <errno.h>
 
-#define BUFFER_SIZE 512
-
 enum arg_keys
 {
     ARG_KEY_DEVICE_FILE = 'd',
     ARG_KEY_REQ_BYTES = 'b',
-    ARG_KEY_REQ_REPEATS = 'r',
+    ARG_KEY_CHUNK_SIZE = 'c',
     ARG_KEY_OUTPUT_FILE = 'o',
     ARG_KEY_LOG_LEVEL = 'l',
     ARG_KEY_USE_SCSI = 's',
@@ -20,12 +18,12 @@ enum arg_keys
 
 static struct argp_option options[] = {
     { "device", ARG_KEY_DEVICE_FILE, "device", 0, "Disk device", 0 },
-    { "bytes", ARG_KEY_REQ_BYTES, "number of bytes", 0, "Number of random bytes within a sequence", 0 },
-    { "repeats", ARG_KEY_REQ_REPEATS, "number of repeats", 0, "Number of random byte sequences to acquire", 0 },
-    { "output", ARG_KEY_OUTPUT_FILE, "file", 0, "Output file", 0 },
+    { "bytes", ARG_KEY_REQ_BYTES, "number of bytes", 0, "Number of random bytes within a sequence (defaults to 32 bytes)", 0 },
+    { "chunk-size", ARG_KEY_CHUNK_SIZE, "size of chunks in bytes", 0, "Divide acquisition of the random sequence into chunks of a specified size (defaults to 512 bytes)", 0 },
+    { "output", ARG_KEY_OUTPUT_FILE, "file", 0, "Output file (defaults to stdout)", 0 },
     { "log-level", ARG_KEY_LOG_LEVEL, "level", 0, "Log level", 0 },
     { "scsi", ARG_KEY_USE_SCSI, 0, 0, "Use SCSI", 0 },
-    { "hex", ARG_KEY_HEX_OUTPUT, 0, 0, "Output random bytes in hexadecimal", 0 },
+    { "hex", ARG_KEY_HEX_OUTPUT, 0, 0, "Output random bytes in hexadecimal (NOT IMPLEMENTED)", 0 },
     { 0 }
 };
 
@@ -34,14 +32,14 @@ struct arguments
     char *dev_file;
     char *out_file_name;
     size_t req_bytes;
-    size_t req_repeats;
+    size_t chunk_size;
     bool use_scsi_sec;
     bool hex_output;
 } args = {
     .dev_file = NULL,
     .out_file_name = NULL,
     .req_bytes = 32,
-    .req_repeats = 1,
+    .chunk_size = 512,
     .use_scsi_sec = false,
     .hex_output = false,
 };
@@ -93,8 +91,8 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
             return 1;
         }
         break;
-    case ARG_KEY_REQ_REPEATS:
-        if (parse_num(arg, &args->req_repeats)) {
+    case ARG_KEY_CHUNK_SIZE:
+        if (parse_num(arg, &args->chunk_size)) {
             return 1;
         }
         break;
@@ -110,11 +108,11 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
         break;
     case ARG_KEY_USE_SCSI:
         args->use_scsi_sec = true;
-	break;
+        break;
     case ARG_KEY_HEX_OUTPUT:
         // args->hex_output = true;
-	fprintf(stderr, "Option -%c not implemented.\n", ARG_KEY_HEX_OUTPUT);
-	print_usage("rng");
+        fprintf(stderr, "Option -%c not implemented.\n", ARG_KEY_HEX_OUTPUT);
+        print_usage("rng");
     default:
         return ARGP_ERR_UNKNOWN;
     }
@@ -135,7 +133,7 @@ int main(int argc, char **argv)
         goto exit;
     }
 
-    if (!(buffer = malloc(BUFFER_SIZE))) {
+    if (!(buffer = malloc(args.chunk_size))) {
         LOG(ERROR, "Out of memory.\n");
         err = 1;
         goto exit;
@@ -155,28 +153,30 @@ int main(int argc, char **argv)
         goto disk_cleanup;
     }
 
-    for (int req_i = 0; req_i < args.req_repeats; ++req_i) {
-        size_t bytes_read = 0;
+    size_t bytes_read = 0;
 
-        while (bytes_read < args.req_bytes) {
-            memset(buffer, 0, BUFFER_SIZE);
-            size_t current_req_bytes = min(args.req_bytes - bytes_read, BUFFER_SIZE);
+    while (bytes_read < args.req_bytes) {
+        memset(buffer, 0, args.chunk_size);
+        size_t current_req_bytes = min(args.req_bytes - bytes_read, args.chunk_size);
 
-            if ((err = get_random(&dev, buffer, current_req_bytes))) {
-                LOG(ERROR, "Failed to get random data.\n");
-                sleep(5);
-                continue;
-            }
-
-            // TODO allow hexadecimal output
-            if (fwrite(buffer, sizeof(char), current_req_bytes, out) != current_req_bytes) {
-                LOG(ERROR, "Failed to write random data.\n");
-                err = 1;
-                break;
-            }
-
-            bytes_read += current_req_bytes;
+        if ((err = get_random(&dev, buffer, current_req_bytes))) {
+            LOG(ERROR, "Failed to get random data.\n");
+            // It might be useful to wait when the disk fails to provide random data
+            // (e.g., to regain enough entropy).
+            // Sleeping should be cut-off after some number of tries.
+            // sleep(5);
+            continue;
         }
+
+        // TODO allow hexadecimal output
+        // TODO decide on using fopen or open solely
+        if (fwrite(buffer, sizeof(char), current_req_bytes, out) != current_req_bytes) {
+            LOG(ERROR, "Failed to write random data.\n");
+            err = 1;
+            break;
+        }
+
+        bytes_read += current_req_bytes;
     }
 
     fclose(out);

--- a/rng.c
+++ b/rng.c
@@ -5,9 +5,10 @@
 
 #include <errno.h>
 
+#define MAIN_DOC_STRING "\n        DEVICE               File of Opal-compliant disk\n"
+
 enum arg_keys
 {
-    ARG_KEY_DEVICE_FILE = 'd',
     ARG_KEY_REQ_BYTES = 'b',
     ARG_KEY_CHUNK_SIZE = 'c',
     ARG_KEY_OUTPUT_FILE = 'o',
@@ -17,7 +18,6 @@ enum arg_keys
 };
 
 static struct argp_option options[] = {
-    { "device", ARG_KEY_DEVICE_FILE, "device", 0, "Disk device", 0 },
     { "bytes", ARG_KEY_REQ_BYTES, "number of bytes", 0, "Number of random bytes within a sequence (defaults to 32 bytes)", 0 },
     { "chunk-size", ARG_KEY_CHUNK_SIZE, "size of chunks in bytes", 0, "Divide acquisition of the random sequence into chunks of a specified size (defaults to 512 bytes)", 0 },
     { "output", ARG_KEY_OUTPUT_FILE, "file", 0, "Output file (defaults to stdout)", 0 },
@@ -83,9 +83,6 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
     struct arguments *args = state->input;
 
     switch (key) {
-    case ARG_KEY_DEVICE_FILE:
-        args->dev_file = arg;
-        break;
     case ARG_KEY_REQ_BYTES:
         if (parse_num(arg, &args->req_bytes)) {
             return 1;
@@ -113,6 +110,13 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
         // args->hex_output = true;
         fprintf(stderr, "Option -%c not implemented.\n", ARG_KEY_HEX_OUTPUT);
         print_usage("rng");
+    case ARGP_KEY_ARG:
+        if (state->arg_num >= 1) {
+            fprintf(stderr, "Too many arguments given.\n");
+            print_usage("rng");
+        }
+        args->dev_file = arg;
+        break;
     default:
         return ARGP_ERR_UNKNOWN;
     }
@@ -120,7 +124,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
     return 0;
 }
 
-static struct argp argp = { options, parse_opt, 0, 0 };
+static struct argp argp = { options, parse_opt, "DEVICE", MAIN_DOC_STRING };
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
This PR introduces

- usage of _argp_ library for parsing CLI arguments and options,
- buffered reading and writing of bytes,
- binary format of the output bytes instead of hexadecimal,
- an option to specify output file.