### PR TITLE
Hotfix for detection of Pyrite V1 drives

### DIFF
--- a/common.c
+++ b/common.c
@@ -103,7 +103,7 @@ static int tcg_discovery_0_process_feature(struct disk_device *dev, void *data, 
     } else if (feature_code == 0x0202) {
         struct level_0_discovery_data_store_feature *body = data;
         dev->features.data_store = *body;
-    } else if (feature_code == 0x0303) {
+    } else if (feature_code == 0x0303 || feature_code == 0x0302) {
         struct level_0_discovery_pyrite_feature *body = data;
         dev->features.pyrite = *body;
         dev->base_com_id = be16_to_cpu(body->base_comID);


### PR DESCRIPTION
Pyrite drives with V1 feature set would cause the program to not recognize the feature set and cause an unknown error with Discovery 1, 2 and rng. This fixes the detection of Pyrite V1, but future changes will be added to differentiate between Pyrite V1 and V2 drives.

Note: This can be done, because Pyrite V1 and V2 feature sets have identical schemas.